### PR TITLE
Update

### DIFF
--- a/bashrc.bash
+++ b/bashrc.bash
@@ -23,6 +23,12 @@ shopt -s histappend
 # custom prompt
 PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 
+# set the title for xterm to user@host:dir
+case "$TERM" in
+xterm* | rxvt*) PS1="\[\e]0;\u@\h: \w\a\]$PS1" ;;
+*) ;;
+esac
+
 # handle macos specific stuff
 if [[ "$OSTYPE" == darwin* ]]; then
     # enable colors for cli applications

--- a/bashrc.bash
+++ b/bashrc.bash
@@ -12,9 +12,6 @@ if ! [[ "$PATH" == *"$HOME/.local/bin:$HOME/bin:"* ]]; then
 fi
 export PATH
 
-# custom prompt
-PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-
 # configure history
 HISTSIZE=1000
 HISTFILESIZE=2000
@@ -22,6 +19,9 @@ HISTCONTROL=ignoreboth
 
 # set bash options
 shopt -s histappend
+
+# custom prompt
+PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 
 # handle macos specific stuff
 if [[ "$OSTYPE" == darwin* ]]; then


### PR DESCRIPTION
This pull request includes changes to the `bashrc.bash` file, mainly focusing on customizing the shell prompt and setting the terminal title for xterm.

Customization of shell prompt and terminal title:

* [`bashrc.bash`](diffhunk://#diff-43a74bdd5ca4845d2fb9c681e7e52e0673c50e715019d13b19b0b92e1d34bcb2R23-R31): Moved the custom prompt configuration (`PS1`) to a different location in the file and added logic to set the terminal title for xterm and rxvt terminals.

Configuration and cleanup:

* [`bashrc.bash`](diffhunk://#diff-43a74bdd5ca4845d2fb9c681e7e52e0673c50e715019d13b19b0b92e1d34bcb2L15-L17): Removed the redundant custom prompt configuration from its original location.