### PR TITLE
Source `$HOME/.ghcup/env` if it exists

### DIFF
--- a/bashrc.bash
+++ b/bashrc.bash
@@ -6,6 +6,11 @@
 export EDITOR=ed
 export VISUAL=vi
 
+# add haskell to path
+if [[ -r "$HOME/.ghcup/env" ]]; then
+    . "$HOME/.ghcup/env"
+fi
+
 # user specific environment
 if ! [[ "$PATH" == *"$HOME/.local/bin:$HOME/bin:"* ]]; then
     PATH="$HOME/.local/bin:$HOME/bin:$PATH"


### PR DESCRIPTION
This pull request includes a small change to the `bashrc.bash` file. The change adds Haskell to the system PATH if the `.ghcup/env` file is readable.

* [`bashrc.bash`](diffhunk://#diff-43a74bdd5ca4845d2fb9c681e7e52e0673c50e715019d13b19b0b92e1d34bcb2R9-R13): Added a conditional block to source the Haskell environment file if it exists and is readable.