### PR TITLE
Update code of path configuration

### DIFF
--- a/bashrc.bash
+++ b/bashrc.bash
@@ -12,10 +12,9 @@ if [[ -r "$HOME/.ghcup/env" ]]; then
 fi
 
 # user specific environment
-if ! [[ "$PATH" == *"$HOME/.local/bin:$HOME/bin:"* ]]; then
-    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+if [[ "$PATH" != *"$HOME/.local/bin:$HOME/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 fi
-export PATH
 
 # configure history
 HISTSIZE=1000


### PR DESCRIPTION
This pull request includes a small but important change to the `bashrc.bash` file. The change ensures that the `PATH` variable is correctly exported if it does not already include specific directories.

* [`bashrc.bash`](diffhunk://#diff-43a74bdd5ca4845d2fb9c681e7e52e0673c50e715019d13b19b0b92e1d34bcb2L15-L18): Modified the condition to check if the `PATH` variable includes `"$HOME/.local/bin:$HOME/bin:"` and added an `export` statement to ensure the `PATH` is properly updated.