### PR TITLE
Refactor code

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -18,10 +18,9 @@ shopt -s histappend
 PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 
 # set the title for xterm to user@host:dir
-case "$TERM" in
-xterm* | rxvt*) PS1="\[\e]0;\u@\h: \w\a\]$PS1" ;;
-*) ;;
-esac
+if [[ "$TERM" == rxvt* || "$TERM" == xterm* ]]; then
+    PS1="\[\e]0;\u@\h: \w\a\]$PS1"
+fi
 
 # handle macos specific stuff
 if [[ "$OSTYPE" == darwin* ]]; then


### PR DESCRIPTION
This pull request includes a small change to the `.bashrc` file. The change modifies the conditional statement that sets the terminal title for `xterm` and `rxvt` to use an `if` statement instead of a `case` statement.

* [`.bashrc`](diffhunk://#diff-b7cf3e96e1f74fc148d130e98db1c65c7b8eb4f5b668668fa71f26768796a5b0L21-R23): Replaced `case` statement with `if` statement for setting the terminal title for `xterm` and `rxvt`.