### PR TITLE
Add `~/.profile` file

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -2,10 +2,6 @@
 # shellcheck shell=bash
 # shellcheck disable=SC1091
 
-# set environment variables
-export EDITOR=ed
-export VISUAL=vi
-
 # configure history
 HISTSIZE=1000
 HISTFILESIZE=2000
@@ -52,11 +48,6 @@ fi
 # add haskell to path
 if [[ -r "$HOME/.ghcup/env" ]]; then
     . "$HOME/.ghcup/env"
-fi
-
-# add users dirs to path
-if [[ "$PATH" != *"$HOME/.local/bin:$HOME/bin:"* ]]; then
-    export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 fi
 
 # enable programmable completion features

--- a/.profile
+++ b/.profile
@@ -29,3 +29,6 @@ fi
 # set EDITOR and VISUAL environment variables
 export EDITOR=ed
 export VISUAL=vi
+
+# set EXINIT environment variable
+export EXINIT="set noflash"

--- a/.profile
+++ b/.profile
@@ -1,0 +1,31 @@
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+# exists.
+# see /usr/share/doc/bash/examples/startup-files for examples.
+# the files are located in the bash-doc package.
+
+# the default umask is set in /etc/profile; for setting the umask
+# for ssh logins, install and configure the libpam-umask package.
+#umask 022
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+	. "$HOME/.bashrc"
+    fi
+fi
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/bin" ]; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/.local/bin" ]; then
+    PATH="$HOME/.local/bin:$PATH"
+fi
+
+# set EDITOR and VISUAL environment variables
+export EDITOR=ed
+export VISUAL=vi

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Simple Bash Config
 - Linux or macOS[^1]
 
 ## :package: Installation
-Download the config to `~/.bashrc`.
+Download the config file to `~/.bashrc`.
 ```sh
 curl -o ~/.bashrc "https://raw.githubusercontent.com/notfirefox/bash-config/main/.bashrc"
+```
+
+Download the profile file to `~/.profile`.
+```sh
+curl -o ~/.profile "https://raw.githubusercontent.com/notfirefox/bash-config/main/.profile"
 ```
 
 [^1]: Use `brew install bash-completion@2` to install bash completion on macOS.


### PR DESCRIPTION
This pull request includes several changes to the `.bashrc` and `.profile` files, as well as updates to the `README.md` file to reflect these changes. The most important changes include moving the environment variable settings from `.bashrc` to `.profile` and updating the documentation accordingly.

Environment variable settings:

* [`.bashrc`](diffhunk://#diff-b7cf3e96e1f74fc148d130e98db1c65c7b8eb4f5b668668fa71f26768796a5b0L5-L8): Removed the export commands for `EDITOR` and `VISUAL`.
* [`.profile`](diffhunk://#diff-ba67a16499c753f76a073fd4a11181721292741b95b1dafde4c5c0a1df8a1725R1-R34): Added export commands for `EDITOR`, `VISUAL`, and `EXINIT` environment variables.

Path configuration:

* [`.bashrc`](diffhunk://#diff-b7cf3e96e1f74fc148d130e98db1c65c7b8eb4f5b668668fa71f26768796a5b0L57-L61): Removed the section that added user directories to the `PATH` variable.
* [`.profile`](diffhunk://#diff-ba67a16499c753f76a073fd4a11181721292741b95b1dafde4c5c0a1df8a1725R1-R34): Added sections to include user's private `bin` directories in the `PATH` variable if they exist.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R18): Updated instructions to download the `.profile` file in addition to the `.bashrc` file.